### PR TITLE
fix: Added missing Typescript types.

### DIFF
--- a/packages/react-maskinput/global.d.ts
+++ b/packages/react-maskinput/global.d.ts
@@ -1,0 +1,4 @@
+interface Window {
+  webkitRequestAnimationFrame?: (callback: FrameRequestCallback) => number;
+  mozRequestAnimationFrame?: (callback: FrameRequestCallback) => number;
+}

--- a/packages/react-maskinput/src/index.tsx
+++ b/packages/react-maskinput/src/index.tsx
@@ -7,8 +7,7 @@ const KEYBOARD = {
   DELETE: 46,
 };
 
-export interface IInputProps {
-  value?: string;
+export interface IInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   mask?: string;
   maskChar?: string;
   maskFormat?: Array<IMaskItem>;
@@ -108,7 +107,6 @@ function MaskInput(props: IInputProps) {
     const raf =
       window.requestAnimationFrame ||
       window.webkitRequestAnimationFrame ||
-      // @ts-ignore
       window.mozRequestAnimationFrame ||
       ((fn) => setTimeout(fn, 0));
     raf(() => inputEl.current.setSelectionRange(selection.start, selection.end));

--- a/packages/react-maskinput/tsconfig.json
+++ b/packages/react-maskinput/tsconfig.json
@@ -7,6 +7,6 @@
     "jsx": "react",
     "declaration": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "global.d.ts"],
   "exclude": ["node_modules", "test", "styleguide"]
 }


### PR DESCRIPTION
I added missing input properties extending from generic input type inside IInputProps interface.

Btw, I created a global type file for webkitRequestAnimationFrame and mozRequestAnimationFrame properties in window.